### PR TITLE
Remove duplicate comma from Polar Station roles

### DIFF
--- a/spyfall/lib/locations.js
+++ b/spyfall/lib/locations.js
@@ -211,7 +211,7 @@ locations = [
       'locations.roles.polar station.biologist',
       'locations.roles.polar station.radioman',
       'locations.roles.polar station.hydrologist',
-      'locations.roles.polar station.meteorologist',,
+      'locations.roles.polar station.meteorologist',
       'locations.roles.polar station.geologist'
     ]
   },


### PR DESCRIPTION
Duplicate comma seemed to be causing role duplication in Polar Station