### PR TITLE
Scaling the number of locations based on the number of players

### DIFF
--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -84,6 +84,8 @@ function getAccessLink(){
     return;
   }
 
+  console.log(game);
+
   return Meteor.settings.public.url + game.accessCode + "/";
 }
 
@@ -485,7 +487,9 @@ Template.gameView.helpers({
     return players;
   },
   locations: function () {
-    return locations;
+    //return locations;
+    var game = getCurrentGame();
+    return game.locations;
   },
   gameFinished: function () {
     var timeRemaining = getTimeRemaining();

--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -84,8 +84,6 @@ function getAccessLink(){
     return;
   }
 
-  console.log(game);
-
   return Meteor.settings.public.url + game.accessCode + "/";
 }
 

--- a/spyfall/server/main.js
+++ b/spyfall/server/main.js
@@ -86,8 +86,6 @@ Games.find({"state": 'settingUp'}).observeChanges({
     });
 
     assignRoles(players, location);
-    
-    
 
     Games.update(id, {$set: {state: 'inProgress', locations: gameLocations, location: location, endTime: gameEndTime, paused: false, pausedTime: null}});
   }


### PR DESCRIPTION
Hello,

We played your game a few times in our office and had a ton of fun! However, we noticed that the victory condition where the spy guesses the location was really hard to accomplish. We played about 10 games, and the spy was never able to even come close to guessing the location. We were playing with 4 players, and our feeling was that the pool of possible locations was too high for that many people.

Proposed solution: scale the size of the location pool based on the number of players

My patch uses the following formula to determine how many locations should be in the game: number_of_locations = 4 + (number_of_locations * 3). This might look a little funky, but it's based around the fact that there are 28 possible locations in the game. The number of locations per game can't exceed the total number of possible locations either ( number_of_locations <= 28 ).

The pool of locations is randomized per game, as well. Also, the primary location (the one where the non-spies are assigned) is picked out of the pool for that particular game.

Thanks for making this awesome game! Let me know if you have any thoughts or questions!