### PR TITLE
Feature/owner lock

### DIFF
--- a/spyfall/client/css/rtl.less
+++ b/spyfall/client/css/rtl.less
@@ -57,4 +57,9 @@
         float: left;
         right: -4px;
     }
+
+
+    .icon-host {
+        float: left;
+    }
 }

--- a/spyfall/client/css/styles.less
+++ b/spyfall/client/css/styles.less
@@ -216,6 +216,12 @@ a {
     float: right;
 }
 
+.icon-host {
+    float: right;
+    vertical-align: middle;
+    margin:5px;
+}
+
 .game-countdown {
     color: #333;
     text-decoration: none;

--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -411,6 +411,17 @@ Template.lobby.helpers({
   accessLink: function () {
     return getAccessLink();
   },
+  currentPlayerCanKick: function() {
+    var player = getCurrentPlayer();
+    var game = getCurrentGame();
+
+    if (!player || !game || ! game.hostLock) {
+      console.log("returning false");
+      return true;
+    }
+    console.log("returning "+player._id === game.host);
+    return (player._id === game.host);
+  },
   player: function () {
     return getCurrentPlayer();
   },
@@ -428,7 +439,7 @@ Template.lobby.helpers({
       if (player._id === currentPlayer._id){
         player.isCurrent = true;
       }
-      if (player._id === game.host) {
+      if (game.hostLock && player._id === game.host) {
         player.isHost = true;
       }
     });

--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -428,6 +428,9 @@ Template.lobby.helpers({
       if (player._id === currentPlayer._id){
         player.isCurrent = true;
       }
+      if (player._id === game.host) {
+        player.isHost = true;
+      }
     });
 
     return players;

--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -542,3 +542,36 @@ Template.gameView.events({
     event.target.className = 'location-name';
   }
 });
+
+Template.statusMessage.helpers({
+  game: getCurrentGame,
+  players: function () {
+    var game = getCurrentGame();
+    
+    if (!game){
+      return null;
+    }
+
+    var players = Players.find({
+      'gameID': game._id
+    });
+
+    return players;
+  },
+  gameFinished: function () {
+    var timeRemaining = getTimeRemaining();
+
+    return timeRemaining === 0;
+  },
+
+  getStatusMessage: function() {
+    TimeRemaining = getTimeRemaining();
+    if (TimeRemaining <= 0) {
+      return TAPi18n.__("ui.game finished");
+    } else if (getCurrentGame().paused) {
+      return TAPi18n.__("ui.paused");
+    } else {
+      return "test"
+    }
+  }
+});

--- a/spyfall/client/main.js
+++ b/spyfall/client/main.js
@@ -286,7 +286,10 @@ Template.createGame.events({
     }
 
     var game = generateNewGame();
+    game.hostLock = event.target.hostLock.checked;
+
     var player = generateNewPlayer(game, playerName);
+    game.host = player;
 
     Meteor.subscribe('games', game.accessCode);
 

--- a/spyfall/client/spyfall.html
+++ b/spyfall/client/spyfall.html
@@ -188,7 +188,10 @@
   <form id="create-game">  
     <div class="">
       <input type="text" id="player-name" name="playerName" placeholder='{{_ "ui.enter your name" }}'>
-
+      <label>
+        <input type="checkbox" id="host-lock" name="hostLock">
+        {{_ "ui.host lock" }}
+      </label>
       <div class="button-container">
         <input type="submit" value='{{_ "ui.create game" }}'>
         <button class="btn-back">{{_ "ui.back" }}</button>

--- a/spyfall/client/spyfall.html
+++ b/spyfall/client/spyfall.html
@@ -94,9 +94,11 @@
             <i class="fa fa-pencil"></i>
           </a>
         {{else}}
-          <a href="#" class="btn-remove-player" data-player-id="{{ _id }}">
-            <i class="fa fa-close"></i>
-          </a>
+          {{#if currentPlayerCanKick}}
+            <a href="#" class="btn-remove-player" data-player-id="{{ _id }}">
+              <i class="fa fa-close"></i>
+            </a>
+          {{/if}}
         {{/if}}
       </li>
     {{/each}}

--- a/spyfall/client/spyfall.html
+++ b/spyfall/client/spyfall.html
@@ -111,6 +111,8 @@
 <template name="gameView">
   <h4><a class="game-countdown {{#if gameFinished }}finished{{/if}} {{#if game.paused }}paused{{/if}}">{{{ timeRemaining }}}</a></h4>
 
+  {{> statusMessage }}
+
   <div class="status-container">
     <button class="btn-toggle-status">{{_ "ui.show hide" }}</button>
 
@@ -249,4 +251,8 @@
     <br>
     <a href="https://github.com/evanbrumley/spyfall" target="_blank">https://github.com/evanbrumley/spyfall</a>
   </div>
+</template>
+
+<template name="statusMessage">
+  <h4 class='status-message'> {{{getStatusMessage}}} </h4>
 </template>

--- a/spyfall/client/spyfall.html
+++ b/spyfall/client/spyfall.html
@@ -86,7 +86,9 @@
     {{#each players }}
       <li>
         {{ name }}
-
+        {{#if isHost}}
+          <i class="icon-host fa fa-gavel"></i>
+        {{/if}}
         {{#if isCurrent }}
           <a href="#" class="btn-edit-player" data-player-id="{{ _id }}">
             <i class="fa fa-pencil"></i>

--- a/spyfall/i18n/en.i18n.json
+++ b/spyfall/i18n/en.i18n.json
@@ -24,6 +24,7 @@
         "invalid access code": "Sorry, no game was found with the access code you provided!",
         "join": "Join",
         "host lock": "Lock buttons to host.",
+        "paused": "Paused",
         "footer": "<a href='http://international.hobbyworld.ru/catalog/25-spyfall/' target='_blank'>Spyfall</a> designed by Alexandr Ushan, published by <a href='http://international.hobbyworld.ru/' target='_blank'>Hobby World</a>"
     },
     "locations": {

--- a/spyfall/i18n/en.i18n.json
+++ b/spyfall/i18n/en.i18n.json
@@ -23,6 +23,7 @@
         "enter an access code": "Enter an access code",
         "invalid access code": "Sorry, no game was found with the access code you provided!",
         "join": "Join",
+        "host lock": "Lock buttons to host.",
         "footer": "<a href='http://international.hobbyworld.ru/catalog/25-spyfall/' target='_blank'>Spyfall</a> designed by Alexandr Ushan, published by <a href='http://international.hobbyworld.ru/' target='_blank'>Hobby World</a>"
     },
     "locations": {

--- a/spyfall/i18n/en.i18n.json
+++ b/spyfall/i18n/en.i18n.json
@@ -24,6 +24,7 @@
         "invalid access code": "Sorry, no game was found with the access code you provided!",
         "join": "Join",
         "host lock": "Lock buttons to host.",
+        "game finished": "Time is up!",
         "paused": "Paused",
         "footer": "<a href='http://international.hobbyworld.ru/catalog/25-spyfall/' target='_blank'>Spyfall</a> designed by Alexandr Ushan, published by <a href='http://international.hobbyworld.ru/' target='_blank'>Hobby World</a>"
     },

--- a/spyfall/server/main.js
+++ b/spyfall/server/main.js
@@ -79,7 +79,7 @@ Games.find({"state": 'settingUp'}).observeChanges({
     });
 
     assignRoles(players, location);
-
-    Games.update(id, {$set: {state: 'inProgress', location: location, endTime: gameEndTime, paused: false, pausedTime: null}});
+    var startTime = new Date;
+    Games.update(id, {$set: {state: 'inProgress', location: location, endTime: gameEndTime, paused: true, pausedTime: startTime}});
   }
 });


### PR DESCRIPTION
The main feature is the ability, during game creation, to make the game "host locked", which means only the host can start/end the game, pause the clock or kick players.

I really enjoy this version of the game, but I felt like anyone being able to press the button, while might be in the spirit of the design (in which everyone is meant to be at the same room to play anyway), just causes troubles as too often too many people try pressing buttons, confusing everyone at best and causing program errors at worst.

The point here is to prevent this by keeping track of the host, denoted by the Gavel favicon, and giving him exclusive control over these button.

Two mini-features which got in even though they definitely shouldn't have:
- The games now start paused, this gives everyone time to read their roles, and search for meanings online if necessary (I know we required it a lot when playing).
- There is a message box that tells you the game is paused, so you no longer have to watch the clock for it.

The following have been added only to the English locale files, and will appear in English in all translations until fixed:
- "host lock": "Lock buttons to host."
- "game finished": "Time is up!"
- "paused": "Paused"
